### PR TITLE
Added link to where to find the rust toolchain version in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ An application template for [RustyHermit](https://github.com/hermitcore/rusty-he
     hermit-sys = "<version>"
     ```
 
-*   Use the exact Rust version required by `hermit-sys` in `rust-toolchain.toml` and make the `rust-src` component available:
+*   Use the exact Rust version [required by `hermit-sys`](https://github.com/hermitcore/rusty-hermit/blob/master/rust-toolchain.toml) in `rust-toolchain.toml` and make the `rust-src` component available:
 
     ```toml
     [toolchain]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ An application template for [RustyHermit](https://github.com/hermitcore/rusty-he
     hermit-sys = "<version>"
     ```
 
-*   Use the exact Rust version [required by `hermit-sys`](https://github.com/hermitcore/rusty-hermit/blob/master/rust-toolchain.toml) in `rust-toolchain.toml` and make the `rust-src` component available:
+*   Use the [exact Rust version] required by `hermit-sys` in `rust-toolchain.toml` and make the `rust-src` component available:
+
+[exact Rust version]: rust-toolchain.toml#L2
 
     ```toml
     [toolchain]


### PR DESCRIPTION
@mkroening Is this actually the best location to find the required toolchain version?