### PR TITLE
README.md: Fix format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An application template for [RustyHermit](https://github.com/hermitcore/rusty-he
 
 *   Use the [exact Rust version] required by `hermit-sys` in `rust-toolchain.toml` and make the `rust-src` component available:
 
-[exact Rust version]: rust-toolchain.toml#L2
+    [exact Rust version]: rust-toolchain.toml#L2
 
     ```toml
     [toolchain]


### PR DESCRIPTION
Turns out, I broke formatting in https://github.com/hermitcore/rusty-demo/commit/f2e7736c9e3fc5872080a7952296e4bc158bf802.

CC: @jounathaen 