### PR TITLE
ci(windows): use winget to install QEMU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install QEMU (windows)
         if: matrix.os == 'windows-latest'
         run: |
-          choco install qemu
+          winget install --id SoftwareFreedomConservancy.QEMU -e --accept-source-agreements
           echo "C:\Program Files\qemu" >> $GITHUB_PATH
       - uses: actions/checkout@v4
       - uses: mkroening/rust-toolchain-toml@main


### PR DESCRIPTION
Winget only takes 1 minute to install QEMU instead of 2. Furthermore, Choco servers for fetching installation instructions are sometimes unreliable. Winget should be more reliable.